### PR TITLE
Run emerge --sync at the end of the installation

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -198,6 +198,8 @@ else
   grub-install --target=i386-pc $drive
 fi
 grub-mkconfig -o /boot/grub/grub.cfg
+
+emerge --sync
 HEREDOC
 
 umount -l /mnt/install/boot/efi /mnt/install/var /mnt/install/usr/local /mnt/install/tmp /mnt/install/srv /mnt/install/root /mnt/install/opt /mnt/install/home /mnt/install/boot/grub/x86_64-efi /mnt/install/boot/grub/i386-pc /mnt/install/.snapshots /mnt/install 1>/dev/null 2>&1


### PR DESCRIPTION
I recommend initializing the portage tree right after the installation. I noticed that you propose to add a world update after the installation - I don't think that's a good idea since it's not unlikely the user wants to modify the build environment before (re-)emerging lots of packages.